### PR TITLE
use balenalib base image

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM resin/%%RESIN_MACHINE_NAME%%-debian
+FROM balenalib/%%BALENA_MACHINE_NAME%%-debian
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Otherwise some device types don't have relevant base images (as they didn't have `resin/...` ones before.

Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>